### PR TITLE
perf: reduce per-frame THREE.Vector3 / THREE.Color allocations

### DIFF
--- a/docs/AGENTS/CONVENTIONS.md
+++ b/docs/AGENTS/CONVENTIONS.md
@@ -17,5 +17,5 @@
 
 - **Throttling**: `ChunkSystem` runs every frame in `useFrame`; only chunks with `needsUpdate: true` are dispatched to the worker pool.
 - **Logic Cadence**: `SystemRunner` may throttle expensive simulation slices on a fixed cadence (currently 10Hz) and should preserve leftover time between frames rather than discarding it.
-- **Hot-Path Allocation**: Prefer reusing scratch vectors/objects inside per-frame ECS systems instead of allocating new `THREE.Vector3` instances in tight loops.
+- **Hot-Path Allocation**: Prefer reusing scratch vectors/objects inside per-frame ECS systems instead of allocating new `THREE.Vector3` instances in tight loops. Apply the same rule to `THREE.Color` in renderers and meshers; use precomputed palettes where possible (see `src/mesher/VoxelMesher.ts`).
 - **Culling**: Meshing implements face culling in `src/mesher/VoxelMesher.ts` (`VoxelMesher.generateChunkMesh`).

--- a/memory/activeContext.md
+++ b/memory/activeContext.md
@@ -1,9 +1,14 @@
 # Active Context — stellar-shell
 
-**Current focus:** Completed a maintenance bundle branch (`fix/maintenance-pass-5-items`) addressing five review findings plus one incidental TypeScript config fix. Awaiting review/merge before resuming roadmap work.
+**Current focus:** Completed `TASK022` (issue #63) — reduced per-frame `THREE.Vector3` / `THREE.Color` allocations across ECS systems, renderers, and chunk meshing. PR pending.
 
 **Recent changes:**
 
+- Completed `TASK022` (design `DES012`):
+  - Removed `THREE` dependency from `VoxelMesher` by switching to a precomputed RGB palette.
+  - Added module-level scratch vectors/colors in `MiningSystem`, `ConstructionSystem`, `MovementSystem`, `Drones.tsx`, and `LaserRenderer.tsx`.
+  - Added regression test for deterministic mesher colors.
+  - Validated with `pnpm lint`, `pnpm typecheck`, `pnpm test` (172 tests), and `pnpm build`.
 - Completed `TASK017` + `TASK018` + `TASK019` + `TASK020` + `TASK021` (design `DES011`):
   - Removed the broken `.github/workflows/profile.yml` (npm/pnpm mismatch + missing `scripts/profile.js`).
   - Updated `README.md` dev server port from `5173` to `3000` to match `vite.config.ts`.

--- a/memory/designs/DES012-reduce-per-frame-allocations.md
+++ b/memory/designs/DES012-reduce-per-frame-allocations.md
@@ -1,0 +1,55 @@
+# DES012 — Reduce Per-Frame Object Allocations in Hot Paths
+
+## Context
+Profiling and code review of the ECS/render loop identified repeated `THREE.Vector3` and `THREE.Color` construction inside per-frame paths. These allocations pressure the GC during active drone swarms and chunk meshing.
+
+## Goal
+Remove unnecessary per-frame object construction from the hottest loops without changing behavior or visual output.
+
+## Requirements (EARS)
+
+- WHEN `MiningSystem` processes a frame, THE SYSTEM SHALL not allocate new `THREE.Vector3` instances for drone world targets or return positions. [Acceptance: unit test or static review confirms scratch-vector usage]
+- WHEN `ConstructionSystem` processes a frame, THE SYSTEM SHALL not allocate new `THREE.Vector3` instances for build targets. [Acceptance: unit test or static review]
+- WHEN `MovementSystem` processes a frame, THE SYSTEM SHALL reuse scratch vectors for separation steering. [Acceptance: existing movement tests still pass; no `new THREE.Vector3` in the hot loop]
+- WHEN `Drones.tsx` renders a frame, THE SYSTEM SHALL not allocate `THREE.Vector3` or `THREE.Color` instances per drone. [Acceptance: render tests or static review]
+- WHEN `LaserRenderer.tsx` renders a frame, THE SYSTEM SHALL not allocate a `THREE.Vector3` per drone target. [Acceptance: render tests or static review]
+- WHEN `VoxelMesher` generates chunk mesh colors, THE SYSTEM SHALL not allocate a `THREE.Color` per visible face. [Acceptance: mesher tests still pass; no `new THREE.Color` in `addFace`]
+
+## Architecture Overview
+
+The change is localized to scratch-object usage inside existing functions. No public API changes are required.
+
+```
+┌─────────────────┐     ┌──────────────────────┐
+│  Systems/Render │────▶│  Module-level scratch │
+│  hot loops      │     │  vectors / colors     │
+└─────────────────┘     └──────────────────────┘
+```
+
+## Implementation Notes
+
+- Prefer module-level `const _scratchVec = new THREE.Vector3()` over inline construction.
+- Use `Vector3.copy()`, `.set()`, `.addVectors()`, `.subVectors()` for arithmetic.
+- In `VoxelMesher.addFace`, compute `BLOCK_COLORS[type]` once per block type at module load (or use a precomputed `THREE.Color` palette) and mutate a single scratch color for noise.
+- Keep function signatures and external behavior identical.
+
+## Test Strategy
+
+1. Unit tests for `MiningSystem`, `ConstructionSystem`, `MovementSystem` already exercise behavior; keep them green.
+2. Add a focused test that inspects `VoxelMesher.generateChunkMesh` output to confirm identical colors/geometry before and after the refactor.
+3. Run the full suite: `pnpm test`, `pnpm lint`, `pnpm typecheck`, `pnpm build`.
+
+## Files Likely to Change
+
+- `src/ecs/systems/MiningSystem.ts`
+- `src/ecs/systems/ConstructionSystem.ts`
+- `src/ecs/systems/MovementSystem.ts`
+- `src/scenes/Drones.tsx`
+- `src/components/renderers/LaserRenderer.tsx`
+- `src/mesher/VoxelMesher.ts`
+- Tests as needed.
+
+## Risks / Tradeoffs
+
+- Scratch vectors are not thread-safe; they are only used on the main thread inside systems/renderers, so this is acceptable.
+- `VoxelMesher` runs in workers; using module-level scratch colors inside a worker is safe because each worker has its own module instance.

--- a/memory/progress.md
+++ b/memory/progress.md
@@ -32,11 +32,14 @@
   - Added inline SVG favicon to stop `/favicon.ico` 404s.
   - Excluded `dist` from `tsconfig.json` so local builds do not break `pnpm typecheck`.
 
+**What works:**
+
+- TASK022 completed: per-frame `THREE.Vector3` / `THREE.Color` allocations removed from `MiningSystem`, `ConstructionSystem`, `MovementSystem`, `Drones.tsx`, `LaserRenderer.tsx`, and `VoxelMesher`.
+
 **What's left / planned work:**
 
 - Gameplay balance tuning after deterministic auto-blueprint expansion changes.
 - Optional cleanup of any remaining non-blocking test-only lint warnings.
-- Continue next feature roadmap item (TBD).
 
 **Known issues / TODOs:**
 
@@ -46,4 +49,4 @@
 - Monitor how often players pin too many builders or explorers so future fallback-borrowing rules can be evaluated from playtesting rather than guesswork.
 - No remaining blocking issues from the review pass.
 
-**Last updated:** 2026-03-23
+**Last updated:** 2026-06-15

--- a/memory/tasks/TASK022-reduce-per-frame-allocations.md
+++ b/memory/tasks/TASK022-reduce-per-frame-allocations.md
@@ -1,0 +1,38 @@
+# TASK022 — Reduce Per-Frame Object Allocations in Hot Paths
+
+**Design:** [DES012](../designs/DES012-reduce-per-frame-allocations.md)  
+**Issue:** [#63](https://github.com/deadronos/stellar-shell/issues/63)  
+**Status:** Completed  
+**Created:** 2026-06-15  
+**Completed:** 2026-06-15
+
+## Goal
+Eliminate per-frame `THREE.Vector3` and `THREE.Color` allocations in the hottest ECS/render loops and in chunk meshing.
+
+## Implementation Checklist
+
+- [x] Create feature branch `perf/reduce-per-frame-allocations-63`.
+- [x] Add/extend tests to capture current behavior (RED baseline).
+- [x] Refactor `MiningSystem` to use scratch vectors.
+- [x] Refactor `ConstructionSystem` to use scratch vectors.
+- [x] Refactor `MovementSystem` to reuse separation vector.
+- [x] Refactor `Drones.tsx` to avoid per-drone `Vector3`/`Color` allocations.
+- [x] Refactor `LaserRenderer.tsx` to avoid per-drone `Vector3` allocation.
+- [x] Refactor `VoxelMesher.ts` to avoid per-face `THREE.Color` allocation.
+- [x] Run validation: `pnpm test`, `pnpm lint`, `pnpm typecheck`, `pnpm build`.
+- [x] Update Memory Bank / docs if needed.
+- [x] Open PR and link issue #63.
+
+## Progress Log
+
+### 2026-06-15 — Analyze & Design
+Created DES012 and this task. Identified six hot paths with object churn.
+
+### 2026-06-15 — Implement & Validate
+- Refactored `VoxelMesher` to use a precomputed RGB palette and removed `THREE` dependency entirely from the mesher.
+- Added scratch vectors/colors in `MiningSystem`, `ConstructionSystem`, `MovementSystem`, `Drones.tsx`, and `LaserRenderer.tsx`.
+- Added regression test in `tests/mesher/voxel-mesher.spec.ts` for deterministic color output.
+- Full validation green: 172 tests, lint, typecheck, and production build.
+
+### Next
+Open PR and link issue #63.

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -4,6 +4,10 @@
 
 - No in progress tasks at the moment.
 
+## Completed
+
+- [TASK022] Reduce Per-Frame Object Allocations - Completed 2026-06-15 - Refactored six hot paths to use scratch vectors/colors or a precomputed RGB palette; issue #63.
+
 ## Pending
 
 - No pending tasks at the moment.

--- a/src/components/renderers/LaserRenderer.tsx
+++ b/src/components/renderers/LaserRenderer.tsx
@@ -10,6 +10,9 @@ export const LaserRenderer = () => {
     [],
   );
 
+  // Scratch target position reused each frame to avoid per-drone allocation.
+  const _targetPosition = useMemo(() => new THREE.Vector3(), []);
+
   // Laser Lines Geometry
   const laserGeo = useMemo(() => {
     const geo = new THREE.BufferGeometry();
@@ -32,9 +35,8 @@ export const LaserRenderer = () => {
         (drone.state === 'MOVING_TO_MINE' || drone.state === 'MOVING_TO_BUILD') &&
         drone.targetBlock
       ) {
-        const dist = drone.position.distanceTo(
-          new THREE.Vector3(drone.targetBlock.x, drone.targetBlock.y, drone.targetBlock.z),
-        );
+        _targetPosition.set(drone.targetBlock.x, drone.targetBlock.y, drone.targetBlock.z);
+        const dist = drone.position.distanceTo(_targetPosition);
         // Show laser if close enough
         if (dist < 3) {
           const idx = laserIdx * 6; // 2 points * 3 coords
@@ -42,9 +44,9 @@ export const LaserRenderer = () => {
           laserPositions[idx + 1] = drone.position.y;
           laserPositions[idx + 2] = drone.position.z;
 
-          laserPositions[idx + 3] = drone.targetBlock.x;
-          laserPositions[idx + 4] = drone.targetBlock.y;
-          laserPositions[idx + 5] = drone.targetBlock.z;
+          laserPositions[idx + 3] = _targetPosition.x;
+          laserPositions[idx + 4] = _targetPosition.y;
+          laserPositions[idx + 5] = _targetPosition.z;
 
           laserIdx++;
         }

--- a/src/ecs/systems/ConstructionSystem.ts
+++ b/src/ecs/systems/ConstructionSystem.ts
@@ -10,6 +10,10 @@ import { getAsteroidOrbitOffset } from '../../services/AsteroidOrbit';
 
 const ENGINE = BvxEngine.getInstance();
 
+// Scratch objects reused across frames to avoid per-frame allocation.
+const _scratchTarget = new THREE.Vector3();
+const _scratchColor = new THREE.Color();
+
 interface ConstructionSystemProps {
   elapsedTime: number;
   asteroidOrbitEnabled: boolean;
@@ -45,12 +49,12 @@ export const ConstructionSystem = ({
 
   for (const drone of buildingDrones) {
     if (drone.state === 'MOVING_TO_BUILD' && drone.targetBlock) {
-      const worldTarget = new THREE.Vector3(
+      _scratchTarget.set(
         drone.targetBlock.x + orbitOffset.x,
         drone.targetBlock.y + orbitOffset.y,
         drone.targetBlock.z + orbitOffset.z,
       );
-      drone.target.copy(worldTarget);
+      drone.target.copy(_scratchTarget);
       const dist = drone.position.distanceTo(drone.target);
 
       if (dist < 1.5) {
@@ -62,11 +66,7 @@ export const ConstructionSystem = ({
             ENGINE.setBlock(x, y, z, BlockType.FRAME);
             BlueprintManager.getInstance().removeBlueprint({ x, y, z });
             setDysonProgress(ENGINE.computeDysonProgress());
-            ParticleEvents.emit(
-              worldTarget.clone(),
-              new THREE.Color(BLOCK_COLORS[BlockType.FRAME]),
-              5,
-            );
+            ParticleEvents.emit(_scratchTarget, _scratchColor.set(BLOCK_COLORS[BlockType.FRAME]), 5);
           }
         } else if (currentBlock === BlockType.FRAME) {
           if (consumeMatter(FRAME_COST) && consumeEnergy(10)) {
@@ -74,7 +74,7 @@ export const ConstructionSystem = ({
             const { energyRate, dysonProgress } = ENGINE.computeWorldDerivedMetrics();
             setEnergyRate(energyRate);
             setDysonProgress(dysonProgress);
-            ParticleEvents.emit(worldTarget.clone(), new THREE.Color(0x00ffff), 8);
+            ParticleEvents.emit(_scratchTarget, _scratchColor.set(0x00ffff), 8);
           }
         } else if (currentBlock === BlockType.PANEL) {
           if (consumeRareMatter(SHELL_COST) && consumeEnergy(50)) {
@@ -82,7 +82,7 @@ export const ConstructionSystem = ({
             const { energyRate, dysonProgress } = ENGINE.computeWorldDerivedMetrics();
             setEnergyRate(energyRate);
             setDysonProgress(dysonProgress);
-            ParticleEvents.emit(worldTarget.clone(), new THREE.Color(0xffaa00), 15);
+            ParticleEvents.emit(_scratchTarget, _scratchColor.set(0xffaa00), 15);
           }
         }
 

--- a/src/ecs/systems/MiningSystem.ts
+++ b/src/ecs/systems/MiningSystem.ts
@@ -9,6 +9,12 @@ import { getAsteroidOrbitOffset } from '../../services/AsteroidOrbit';
 const ENGINE = BvxEngine.getInstance();
 const HUB_POSITION = new THREE.Vector3(0, 0, 0);
 
+// Scratch objects reused across frames to avoid per-frame allocation.
+const _scratchTarget = new THREE.Vector3();
+const _scratchOffset = new THREE.Vector3();
+const _scratchColor = new THREE.Color();
+const _scratchRed = new THREE.Color('#ff0000');
+
 interface MiningSystemProps {
   delta: number;
   elapsedTime: number;
@@ -52,12 +58,12 @@ export const MiningSystem = ({
 
   for (const drone of miningDrones) {
     if (drone.state === 'MOVING_TO_MINE' && drone.targetBlock) {
-      const worldTarget = new THREE.Vector3(
+      _scratchTarget.set(
         drone.targetBlock.x + orbitOffset.x,
         drone.targetBlock.y + orbitOffset.y,
         drone.targetBlock.z + orbitOffset.z,
       );
-      drone.target.copy(worldTarget);
+      drone.target.copy(_scratchTarget);
       const dist = drone.position.distanceTo(drone.target);
       // Arrival Check
       if (dist < 1.5) {
@@ -91,10 +97,10 @@ export const MiningSystem = ({
           // Visual feedback: If out of energy, emit red "exhaust" sparks instead of material-colored ones
           if (Math.random() < particleThreshold) {
             const color = hasEnergy
-              ? new THREE.Color(BLOCK_COLORS[block] || '#ffffff')
-              : new THREE.Color('#ff0000'); // Low power alert color
+              ? _scratchColor.set(BLOCK_COLORS[block] || '#ffffff')
+              : _scratchRed;
 
-            ParticleEvents.emit(worldTarget.clone(), color, 1);
+            ParticleEvents.emit(_scratchTarget, color, 1);
           }
 
           if (drone.miningProgress >= 100) {
@@ -105,14 +111,12 @@ export const MiningSystem = ({
             drone.miningProgress = 0;
 
             // Set new target: Hub
-            const returnPos = HUB_POSITION.clone().add(
-              new THREE.Vector3(
-                (Math.random() - 0.5) * 8,
-                (Math.random() - 0.5) * 4,
-                (Math.random() - 0.5) * 8,
-              ),
+            _scratchOffset.set(
+              (Math.random() - 0.5) * 8,
+              (Math.random() - 0.5) * 4,
+              (Math.random() - 0.5) * 8,
             );
-            drone.target.copy(returnPos);
+            drone.target.copy(HUB_POSITION).add(_scratchOffset);
             ECS.removeComponent(drone, 'targetBlock');
           }
           // Else: Stay here and keep mining next frame

--- a/src/ecs/systems/MovementSystem.ts
+++ b/src/ecs/systems/MovementSystem.ts
@@ -7,6 +7,7 @@ const MAX_SEPARATION_DISTANCE_SQ = 6.25; // 2.5^2
 const steeringDesired = new THREE.Vector3();
 const steeringDelta = new THREE.Vector3();
 const separationPush = new THREE.Vector3();
+const separationSum = new THREE.Vector3();
 
 interface MovementSystemProps {
   delta: number;
@@ -75,7 +76,7 @@ export const MovementSystem = ({ delta, energy, prestigeLevel, upgrades }: Movem
     const d1 = allDrones[i];
     if (!d1.velocity) continue;
 
-    const separation = new THREE.Vector3();
+    separationSum.set(0, 0, 0);
     let neighbors = 0;
 
     const pos = d1.position;
@@ -99,7 +100,7 @@ export const MovementSystem = ({ delta, energy, prestigeLevel, upgrades }: Movem
             if (distSq > 0 && distSq < MAX_SEPARATION_DISTANCE_SQ) {
               separationPush.subVectors(d1.position, d2.position);
               separationPush.multiplyScalar(1 / distSq);
-              separation.add(separationPush);
+              separationSum.add(separationPush);
               neighbors++;
             }
           }
@@ -108,8 +109,8 @@ export const MovementSystem = ({ delta, energy, prestigeLevel, upgrades }: Movem
     }
 
     if (neighbors > 0) {
-      separation.divideScalar(neighbors).multiplyScalar(20 * delta);
-      d1.velocity.add(separation);
+      separationSum.divideScalar(neighbors).multiplyScalar(20 * delta);
+      d1.velocity.add(separationSum);
     }
 
     d1.velocity.clampLength(0, maxDroneSpeed);

--- a/src/mesher/VoxelMesher.ts
+++ b/src/mesher/VoxelMesher.ts
@@ -1,7 +1,19 @@
-import * as THREE from 'three';
 import { BlockType } from '../types';
 import { CHUNK_SIZE, IS_TRANSPARENT, BLOCK_COLORS } from '../constants';
 import { IVoxelSource } from '../services/voxel/types';
+
+// Precompute base RGB values for each block type to avoid per-face THREE.Color allocation.
+const BASE_RGB: Record<number, [number, number, number]> = {};
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  const normalized = hex.startsWith('#') ? hex.slice(1) : hex;
+  const parsed = parseInt(normalized, 16);
+  return [((parsed >> 16) & 0xff) / 255, ((parsed >> 8) & 0xff) / 255, (parsed & 0xff) / 255];
+};
+
+for (const [type, hex] of Object.entries(BLOCK_COLORS)) {
+  BASE_RGB[Number(type)] = hexToRgb(hex);
+}
 
 export class VoxelMesher {
   public static generateChunkMesh(
@@ -141,20 +153,22 @@ export class VoxelMesher {
     norm.push(...normal, ...normal, ...normal, ...normal);
 
     // Color
-    const colorHex = BLOCK_COLORS[type] || '#ff00ff';
-    const c = new THREE.Color(colorHex);
+    const [br, bg, bb] = BASE_RGB[type] ?? [1, 0, 1];
+    let r = br;
+    let g = bg;
+    let b = bb;
 
     // Add visual noise to surface/core blocks for "texture" without actual textures
     if (type === BlockType.ASTEROID_SURFACE || type === BlockType.ASTEROID_CORE) {
       // Deterministic pseudo-random noise based on world position to avoid flickering
       const noiseVal = (Math.sin(x * 12.9898 + y * 78.233 + z * 53.53) * 43758.5453) % 1;
       const variance = (noiseVal - 0.5) * 0.15; // +/- 7% brightness
-      c.r = Math.max(0, Math.min(1, c.r + variance));
-      c.g = Math.max(0, Math.min(1, c.g + variance));
-      c.b = Math.max(0, Math.min(1, c.b + variance));
+      r = Math.max(0, Math.min(1, r + variance));
+      g = Math.max(0, Math.min(1, g + variance));
+      b = Math.max(0, Math.min(1, b + variance));
     }
 
-    col.push(c.r, c.g, c.b, c.r, c.g, c.b, c.r, c.g, c.b, c.r, c.g, c.b);
+    col.push(r, g, b, r, g, b, r, g, b, r, g, b);
 
     // Indices (2 triangles)
     ind.push(i, i + 1, i + 2);

--- a/src/scenes/Drones.tsx
+++ b/src/scenes/Drones.tsx
@@ -7,6 +7,11 @@ import { ECS } from '../ecs/world';
 import { ParticleSystemRenderer } from '../components/renderers/ParticleSystemRenderer';
 import { LaserRenderer } from '../components/renderers/LaserRenderer';
 
+// Module-level scratch objects reused every frame to avoid per-drone allocation.
+const _lookAtTarget = new THREE.Vector3();
+const _cargoOffset = new THREE.Vector3(0, -0.4, 0);
+const _cargoColor = new THREE.Color();
+
 export const Drones = () => {
   const droneCount = useStore((state) => state.droneCount);
   const droneMeshRef = useRef<THREE.InstancedMesh>(null);
@@ -27,7 +32,8 @@ export const Drones = () => {
       dummy.position.copy(drone.position);
 
       if (drone.velocity && drone.velocity.lengthSq() > 0.1) {
-        dummy.lookAt(drone.position.clone().add(drone.velocity));
+        _lookAtTarget.copy(drone.position).add(drone.velocity);
+        dummy.lookAt(_lookAtTarget);
       }
 
       dummy.scale.set(0.3, 0.3, 0.5);
@@ -37,14 +43,14 @@ export const Drones = () => {
       // Cargo
       if (drone.carryingType) {
         // ... (existing cargo logic)
-        dummyCargo.position.copy(drone.position).add(new THREE.Vector3(0, -0.4, 0));
+        dummyCargo.position.copy(drone.position).add(_cargoOffset);
         dummyCargo.rotation.copy(dummy.rotation);
         dummyCargo.scale.set(0.25, 0.25, 0.25);
         dummyCargo.updateMatrix();
         cargoMeshRef.current.setMatrixAt(i, dummyCargo.matrix);
 
         const colorHex = BLOCK_COLORS[drone.carryingType] || '#ffffff';
-        cargoMeshRef.current.setColorAt(i, new THREE.Color(colorHex));
+        cargoMeshRef.current.setColorAt(i, _cargoColor.set(colorHex));
       } else {
         dummyCargo.scale.set(0, 0, 0); // Hide
         dummyCargo.updateMatrix();

--- a/tests/mesher/voxel-mesher.spec.ts
+++ b/tests/mesher/voxel-mesher.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
 import { VoxelMesher } from '../../src/mesher/VoxelMesher';
+import { BLOCK_COLORS } from '../../src/constants';
 import { BlockType } from '../../src/types';
 
 describe('VoxelMesher', () => {
@@ -115,6 +117,30 @@ describe('VoxelMesher', () => {
       // Internal face should be culled (same transparent type)
       // 2 blocks = 10 faces expected
       expect(mesh.positions.length).toBe(10 * 4 * 3);
+    });
+  });
+
+  describe('Allocation efficiency', () => {
+    it('produces deterministic colors without allocating a THREE.Color per face', () => {
+      const source = {
+        getBlock: (x: number, y: number, z: number) => {
+          if (x === 0 && y === 0 && z === 0) return BlockType.ASTEROID_SURFACE;
+          return BlockType.AIR;
+        },
+      };
+
+      const mesh1 = VoxelMesher.generateChunkMesh(0, 0, 0, source);
+      const mesh2 = VoxelMesher.generateChunkMesh(0, 0, 0, source);
+
+      expect(mesh1.colors).toEqual(mesh2.colors);
+      expect(mesh1.colors.length).toBe(6 * 4 * 3); // 6 faces, 4 vertices, 3 channels
+
+      // Spot check: first vertex color should be in valid range and match the base color palette.
+      const baseColor = new THREE.Color(BLOCK_COLORS[BlockType.ASTEROID_SURFACE] || '#ffffff');
+      expect(mesh1.colors[0]).toBeGreaterThanOrEqual(0);
+      expect(mesh1.colors[0]).toBeLessThanOrEqual(1);
+      // The mesher applies a small deterministic noise variance around the base color.
+      expect(Math.abs(mesh1.colors[0] - baseColor.r)).toBeLessThan(0.25);
     });
   });
 });


### PR DESCRIPTION
## Goal

Eliminate per-frame `THREE.Vector3` and `THREE.Color` allocations in the hottest ECS/render loops and in chunk meshing (closes #63).

## Key Changes

- `src/mesher/VoxelMesher.ts`
  - Removed the `three` import entirely.
  - Added a precomputed `BASE_RGB` palette parsed from `BLOCK_COLORS`.
  - Replaced per-face `new THREE.Color()` construction with raw number color channels.

- `src/ecs/systems/MiningSystem.ts`
  - Reused scratch vectors for world targets, hub return offsets, and particle positions.
  - Reused scratch colors for material-colored and low-power spark emissions.

- `src/ecs/systems/ConstructionSystem.ts`
  - Reused scratch vector for build targets and scratch color for particle emissions.

- `src/ecs/systems/MovementSystem.ts`
  - Reused a single scratch vector for separation summation instead of allocating per drone.

- `src/scenes/Drones.tsx`
  - Reused scratch vector for `dummy.lookAt` target.
  - Reused scratch vector for cargo offset.
  - Reused scratch color for cargo instanced mesh colors.

- `src/components/renderers/LaserRenderer.tsx`
  - Reused scratch vector for target-block distance checks and laser endpoint positions.

- `tests/mesher/voxel-mesher.spec.ts`
  - Added regression test asserting deterministic color output and expected vertex color count.

- `docs/AGENTS/CONVENTIONS.md`
  - Extended the hot-path allocation guideline to cover `THREE.Color` and precomputed palettes.

- Memory Bank
  - Added `DES012-reduce-per-frame-allocations.md` and `TASK022-reduce-per-frame-allocations.md`.
  - Updated `activeContext.md`, `progress.md`, and `tasks/_index.md`.

## Validation

- `pnpm test` — 172 tests passed
- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm build` — production build succeeded

## Follow-ups

- Monitor frame-time/GC behavior in live playtesting, especially with large drone swarms.
- Consider applying the same scratch-object pattern to any future per-frame loops.
