### PR TITLE
Replace brute-force chunk scans with incremental spatial indexes

### DIFF
--- a/src/services/BvxEngine.ts
+++ b/src/services/BvxEngine.ts
@@ -10,6 +10,21 @@ import { VoxelQuery } from './voxel/VoxelQuery';
 import { VoxelWorld, VoxelChunk8, MortonKey, VoxelIndex } from '@astrumforge/bvx-kit';
 import { BlueprintManager } from './BlueprintManager';
 
+const NEIGHBOR_DIRS: [number, number, number][] = [
+  [1, 0, 0],
+  [-1, 0, 0],
+  [0, 1, 0],
+  [0, -1, 0],
+  [0, 0, 1],
+  [0, 0, -1],
+];
+
+const MINE_TYPES = new Set<BlockType>([
+  BlockType.ASTEROID_SURFACE,
+  BlockType.ASTEROID_CORE,
+  BlockType.RARE_ORE,
+]);
+
 export class BvxEngine {
   private static readonly DYSON_BLUEPRINT_RADIUS = 24;
   private static readonly DYSON_BLUEPRINT_NODE_COUNT = 64;
@@ -28,6 +43,14 @@ export class BvxEngine {
     panels: 0,
     shells: 0,
   };
+
+  // Incremental spatial indexes (issue #66)
+  // Exposed blocks (ASTEROID_SURFACE, ASTEROID_CORE, RARE_ORE) with at least one AIR or FRAME neighbor
+  private exposedMines = new Set<string>();
+  // All FRAME blocks eligible for PANEL upgrade
+  private buildableFrames = new Set<string>();
+  // All PANEL blocks eligible for SHELL upgrade
+  private buildablePanels = new Set<string>();
 
   // Singleton pattern for the engine core
   private static instance: BvxEngine;
@@ -122,6 +145,78 @@ export class BvxEngine {
     this.counters = this.scanDysonCounts();
   }
 
+  // ── Incremental spatial index helpers ──────────────────────────────────────
+
+  private posKey(x: number, y: number, z: number): string {
+    return `${x},${y},${z}`;
+  }
+
+  private isMineType(block: BlockType): boolean {
+    return MINE_TYPES.has(block);
+  }
+
+  /** Check whether a block at (x,y,z) has at least one AIR or FRAME neighbor. */
+  private isExposed(x: number, y: number, z: number): boolean {
+    for (const [dx, dy, dz] of NEIGHBOR_DIRS) {
+      const neighbor = this.getBlock(x + dx, y + dy, z + dz);
+      if (neighbor === BlockType.AIR || neighbor === BlockType.FRAME) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Evaluate whether the block at (x,y,z) should appear in exposedMines.
+   * Call after any block change that could affect this position's exposure.
+   */
+  private evaluateBlockForMining(x: number, y: number, z: number): void {
+    const key = this.posKey(x, y, z);
+    this.exposedMines.delete(key);
+
+    const block = this.getBlock(x, y, z);
+    if (!this.isMineType(block)) return;
+
+    if (this.isExposed(x, y, z)) {
+      this.exposedMines.add(key);
+    }
+  }
+
+  /**
+   * Evaluate whether the block at (x,y,z) should appear in buildableFrames
+   * or buildablePanels. Building eligibility depends only on the block type
+   * itself, not on neighbors.
+   */
+  private evaluateBlockForBuilding(x: number, y: number, z: number): void {
+    const key = this.posKey(x, y, z);
+    this.buildableFrames.delete(key);
+    this.buildablePanels.delete(key);
+
+    const block = this.getBlock(x, y, z);
+    if (block === BlockType.FRAME) {
+      this.buildableFrames.add(key);
+    } else if (block === BlockType.PANEL) {
+      this.buildablePanels.add(key);
+    }
+  }
+
+  /**
+   * After a block change at (wx,wy,wz), re-evaluate the changed position
+   * and all 6 neighbors to keep spatial indexes consistent.
+   */
+  private updateSpatialIndexes(wx: number, wy: number, wz: number): void {
+    // Re-evaluate the changed position
+    this.evaluateBlockForMining(wx, wy, wz);
+    this.evaluateBlockForBuilding(wx, wy, wz);
+
+    // Re-evaluate neighbors (their exposure may have changed)
+    for (const [dx, dy, dz] of NEIGHBOR_DIRS) {
+      this.evaluateBlockForMining(wx + dx, wy + dy, wz + dz);
+      // Building sets only depend on the block itself, not on neighbors,
+      // so we only re-evaluate building for the changed position above.
+    }
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
   public setBlock(wx: number, wy: number, wz: number, type: BlockType) {
     // 1. Update bvx-kit VoxelWorld
     // bvx-kit uses 4x4x4 chunks.
@@ -186,6 +281,9 @@ export class BvxEngine {
 
     // Mark neighbors dirty if on boundary
     this.markNeighborsDirty(wx, wy, wz, cx, cy, cz);
+
+    // 3. Update incremental spatial indexes
+    this.updateSpatialIndexes(wx, wy, wz);
   }
 
   private markNeighborsDirty(
@@ -245,12 +343,24 @@ export class BvxEngine {
     return (bChunk as VoxelChunk8).getMetaData(vIndex) as BlockType;
   }
 
-  // Find blocks of specific type
+  // Find blocks of specific type — queries incremental spatial indexes instead of full world scan.
   public findBlocksByType(
     type: BlockType,
     limit: number = 20,
   ): { x: number; y: number; z: number }[] {
-    return VoxelQuery.findBlocksByType(this.chunkEntities.values(), this, type, limit);
+    const blocks: { x: number; y: number; z: number }[] = [];
+
+    let source: Set<string>;
+    if (type === BlockType.FRAME) source = this.buildableFrames;
+    else if (type === BlockType.PANEL) source = this.buildablePanels;
+    else return []; // Unhandled types have no index
+
+    for (const key of source) {
+      if (blocks.length >= limit) break;
+      const [x, y, z] = key.split(',').map(Number);
+      blocks.push({ x, y, z });
+    }
+    return blocks;
   }
 
   // Compute the energy generation rate from actual voxel world state (single source of truth).
@@ -324,14 +434,25 @@ export class BvxEngine {
       shells: 0,
     };
 
+    // Reset incremental spatial indexes
+    this.exposedMines.clear();
+    this.buildableFrames.clear();
+    this.buildablePanels.clear();
+
     // Clear blueprint overlays so stale markers don't persist in the new system
     blueprints.reset();
     this.refreshDysonCountersFromWorld();
   }
 
-  // Find valid mining targets (Asteroids) - Prefer exposed surface blocks
+  // Find valid mining targets (Asteroids) — queries the incremental exposedMines index.
   public findMiningTargets(limit: number = 20): { x: number; y: number; z: number }[] {
-    return VoxelQuery.findMiningTargets(this.chunkEntities.values(), this, limit);
+    const targets: { x: number; y: number; z: number }[] = [];
+    for (const key of this.exposedMines) {
+      if (targets.length >= limit) break;
+      const [x, y, z] = key.split(',').map(Number);
+      targets.push({ x, y, z });
+    }
+    return targets;
   }
 
   // Procedural Generation

--- a/src/services/BvxEngine.ts
+++ b/src/services/BvxEngine.ts
@@ -343,7 +343,20 @@ export class BvxEngine {
     return (bChunk as VoxelChunk8).getMetaData(vIndex) as BlockType;
   }
 
-  // Find blocks of specific type — queries incremental spatial indexes instead of full world scan.
+  /**
+   * Find blocks of a given type using incremental spatial indexes.
+   *
+   * Supported types:
+   * - `BlockType.FRAME` — queries the `buildableFrames` index
+   * - `BlockType.PANEL` — queries the `buildablePanels` index
+   *
+   * Other types (SHELL, BLUEPRINT_FRAME, ASTEROID_*, etc.) return `[]` since they
+   * have no dedicated index. Callers should handle empty results gracefully.
+   *
+   * @param type  Block type to look up.
+   * @param limit Maximum number of results to return (default 20).
+   * @returns Array of world-space positions matching the type.
+   */
   public findBlocksByType(
     type: BlockType,
     limit: number = 20,
@@ -444,7 +457,16 @@ export class BvxEngine {
     this.refreshDysonCountersFromWorld();
   }
 
-  // Find valid mining targets (Asteroids) — queries the incremental exposedMines index.
+  /**
+   * Find valid mining targets from the `exposedMines` index.
+   *
+   * Only blocks that are minable types (ASTEROID_SURFACE, ASTEROID_CORE, RARE_ORE)
+   * **and** have at least one AIR or FRAME neighbor are included. Buried blocks are
+   * excluded.
+   *
+   * @param limit Maximum number of targets to return (default 20).
+   * @returns Array of world-space positions of exposed minable blocks.
+   */
   public findMiningTargets(limit: number = 20): { x: number; y: number; z: number }[] {
     const targets: { x: number; y: number; z: number }[] = [];
     for (const key of this.exposedMines) {

--- a/src/services/voxel/VoxelQuery.ts
+++ b/src/services/voxel/VoxelQuery.ts
@@ -1,11 +1,16 @@
 import { BlockType } from '../../types';
 import { CHUNK_SIZE } from '../../constants';
-import { Entity } from '../../ecs/world';
 import { IVoxelSource } from './types';
 
 /** Block types that count as "completed" Dyson-sphere construction. */
 const COMPLETED_DYSON_TYPES = new Set<BlockType>([BlockType.PANEL, BlockType.SHELL]);
 
+/**
+ * Stateless voxel queries that operate on a single chunk or simple source.
+ *
+ * NOTE: World-scanning methods (findMiningTargets, findBlocksByType) have been
+ * replaced by incremental spatial indexes in BvxEngine (see issue #66).
+ */
 export class VoxelQuery {
   /**
    * Returns true when every solid (non-AIR) voxel in the given render chunk
@@ -34,111 +39,5 @@ export class VoxelQuery {
       }
     }
     return solidCount > 0;
-  }
-
-  // Find blocks of a specific type
-  public static findBlocksByType(
-    chunkEntities: Iterable<Entity>,
-    voxelSource: IVoxelSource,
-    type: BlockType,
-    limit: number = 20,
-  ): { x: number; y: number; z: number }[] {
-    const blocks: { x: number; y: number; z: number }[] = [];
-
-    // Iterating over Render Chunks (Entities)
-    for (const entity of chunkEntities) {
-      if (blocks.length >= limit) break;
-      if (!entity.chunkPosition) continue;
-      const { x: cx, y: cy, z: cz } = entity.chunkPosition;
-
-      // Iterate all voxels in this logical chunk
-      for (let x = 0; x < CHUNK_SIZE; x++) {
-        for (let y = 0; y < CHUNK_SIZE; y++) {
-          for (let z = 0; z < CHUNK_SIZE; z++) {
-            if (blocks.length >= limit) break;
-            const wx = cx * CHUNK_SIZE + x;
-            const wy = cy * CHUNK_SIZE + y;
-            const wz = cz * CHUNK_SIZE + z;
-
-            if (voxelSource.getBlock(wx, wy, wz) === type) {
-              blocks.push({ x: wx, y: wy, z: wz });
-            }
-          }
-        }
-      }
-    }
-
-    return blocks;
-  }
-
-  // Find valid mining targets (Asteroids) - Prefer exposed surface blocks
-  public static findMiningTargets(
-    chunkEntities: Iterable<Entity>,
-    voxelSource: IVoxelSource,
-    limit: number = 20,
-  ): { x: number; y: number; z: number }[] {
-    const targets: { x: number; y: number; z: number }[] = [];
-    const directions = [
-      [1, 0, 0],
-      [-1, 0, 0],
-      [0, 1, 0],
-      [0, -1, 0],
-      [0, 0, 1],
-      [0, 0, -1],
-    ];
-
-    // ...
-    // Debug counter
-    let potentialFound = 0;
-
-    // Scan Chunk Entities
-    for (const entity of chunkEntities) {
-      if (targets.length >= limit) break;
-      if (!entity.chunkPosition) continue;
-      const { x: cx, y: cy, z: cz } = entity.chunkPosition;
-
-      for (let x = 0; x < CHUNK_SIZE; x++) {
-        for (let y = 0; y < CHUNK_SIZE; y++) {
-          for (let z = 0; z < CHUNK_SIZE; z++) {
-            if (targets.length >= limit) break;
-
-            const wx = cx * CHUNK_SIZE + x;
-            const wy = cy * CHUNK_SIZE + y;
-            const wz = cz * CHUNK_SIZE + z;
-
-            const block = voxelSource.getBlock(wx, wy, wz);
-
-            if (
-              block === BlockType.ASTEROID_SURFACE ||
-              block === BlockType.ASTEROID_CORE ||
-              block === BlockType.RARE_ORE
-            ) {
-              potentialFound++;
-              // Check exposure
-              let isExposed = false;
-              for (const dir of directions) {
-                const neighbor = voxelSource.getBlock(wx + dir[0], wy + dir[1], wz + dir[2]);
-                if (neighbor === BlockType.AIR || neighbor === BlockType.FRAME) {
-                  isExposed = true;
-                  break;
-                }
-              }
-
-              if (isExposed) {
-                targets.push({ x: wx, y: wy, z: wz });
-              }
-            }
-          }
-        }
-      }
-    }
-
-    if (Math.random() < 0.05) {
-      console.log(
-        `[VoxelQuery] Scan complete. Potential: ${potentialFound}. Found: ${targets.length}. Limit: ${limit}`,
-      );
-    }
-
-    return targets;
   }
 }

--- a/tests/services/bvx-engine-indexes.spec.ts
+++ b/tests/services/bvx-engine-indexes.spec.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BvxEngine } from '../../src/services/BvxEngine';
+import { BlockType } from '../../src/types';
+import { ECS } from '../../src/ecs/world';
+import { BlueprintManager } from '../../src/services/BlueprintManager';
+
+/**
+ * Tests for the incremental spatial indexes added in issue #66.
+ *
+ * These verify that the exposedMines, buildableFrames, and buildablePanels
+ * sets maintained by BvxEngine stay consistent after any sequence of
+ * setBlock calls.
+ */
+
+describe('BvxEngine spatial indexes (issue #66)', () => {
+  let engine: BvxEngine;
+
+  beforeEach(() => {
+    const entities = [...ECS.entities];
+    for (const entity of entities) {
+      ECS.remove(entity);
+    }
+    engine = new BvxEngine();
+  });
+
+  // ── Exposed Mines index ──────────────────────────────────────────────────
+
+  describe('exposedMines index', () => {
+    it('includes an exposed ASTEROID_SURFACE block', () => {
+      engine.setBlock(5, 5, 5, BlockType.ASTEROID_SURFACE);
+
+      const targets = engine.findMiningTargets(100);
+      expect(targets).toContainEqual({ x: 5, y: 5, z: 5 });
+    });
+
+    it('includes an exposed ASTEROID_CORE block', () => {
+      engine.setBlock(5, 5, 5, BlockType.ASTEROID_CORE);
+
+      const targets = engine.findMiningTargets(100);
+      expect(targets).toContainEqual({ x: 5, y: 5, z: 5 });
+    });
+
+    it('includes an exposed RARE_ORE block', () => {
+      engine.setBlock(5, 5, 5, BlockType.RARE_ORE);
+
+      const targets = engine.findMiningTargets(100);
+      expect(targets).toContainEqual({ x: 5, y: 5, z: 5 });
+    });
+
+    it('excludes a mine-type block surrounded by solid neighbors (not exposed)', () => {
+      // Surround (5,5,5) with solid blocks
+      engine.setBlock(4, 5, 5, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(6, 5, 5, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(5, 4, 5, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(5, 6, 5, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(5, 5, 4, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(5, 5, 6, BlockType.ASTEROID_SURFACE);
+      // The center block
+      engine.setBlock(5, 5, 5, BlockType.ASTEROID_CORE);
+
+      const targets = engine.findMiningTargets(100);
+      expect(targets.find((t) => t.x === 5 && t.y === 5 && t.z === 5)).toBeUndefined();
+    });
+
+    it('excludes non-mine block types', () => {
+      engine.setBlock(5, 5, 5, BlockType.FRAME);
+      engine.setBlock(6, 6, 6, BlockType.PANEL);
+      engine.setBlock(7, 7, 7, BlockType.SHELL);
+
+      expect(engine.findMiningTargets(100).length).toBe(0);
+    });
+
+    it('removes a block from indexes when it is changed to AIR', () => {
+      engine.setBlock(5, 5, 5, BlockType.ASTEROID_SURFACE);
+      expect(engine.findMiningTargets(100)).toContainEqual({ x: 5, y: 5, z: 5 });
+
+      engine.setBlock(5, 5, 5, BlockType.AIR);
+      expect(engine.findMiningTargets(100).find((t) => t.x === 5 && t.y === 5 && t.z === 5)).toBeUndefined();
+    });
+
+    it('updates exposure when a neighboring block is removed (exposing a new mine)', () => {
+      // Place a core block fully surrounded
+      engine.setBlock(5, 5, 5, BlockType.ASTEROID_CORE);
+      engine.setBlock(4, 5, 5, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(6, 5, 5, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(5, 4, 5, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(5, 6, 5, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(5, 5, 4, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(5, 5, 6, BlockType.ASTEROID_SURFACE);
+
+      expect(engine.findMiningTargets(100).find((t) => t.x === 5 && t.y === 5 && t.z === 5)).toBeUndefined();
+
+      // Remove one neighbor — core becomes exposed
+      engine.setBlock(4, 5, 5, BlockType.AIR);
+
+      expect(engine.findMiningTargets(100)).toContainEqual({ x: 5, y: 5, z: 5 });
+    });
+
+    it('removes a mine from the index when it is no longer exposed', () => {
+      // A mine with air neighbors is exposed
+      engine.setBlock(5, 5, 5, BlockType.ASTEROID_SURFACE);
+      expect(engine.findMiningTargets(100)).toContainEqual({ x: 5, y: 5, z: 5 });
+
+      // Fill the neighbor (4,5,5) with solid — (5,5,5) becomes buried
+      engine.setBlock(4, 5, 5, BlockType.ASTEROID_SURFACE);
+
+      // (5,5,5) still exposed through other faces
+      // To fully bury it, fill all 6 neighbors
+      engine.setBlock(6, 5, 5, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(5, 4, 5, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(5, 6, 5, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(5, 5, 4, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(5, 5, 6, BlockType.ASTEROID_SURFACE);
+
+      // With the first neighbor already set, all 6 are solid
+      expect(engine.findMiningTargets(100).find((t) => t.x === 5 && t.y === 5 && t.z === 5)).toBeUndefined();
+    });
+
+    it('considers FRAME as an exposing neighbor (drone can mine through frames)', () => {
+      engine.setBlock(5, 5, 5, BlockType.ASTEROID_CORE);
+      engine.setBlock(4, 5, 5, BlockType.FRAME);
+
+      const targets = engine.findMiningTargets(100);
+      expect(targets).toContainEqual({ x: 5, y: 5, z: 5 });
+    });
+  });
+
+  // ── Buildable Frames index (FRAME → PANEL) ──────────────────────────────
+
+  describe('buildableFrames index', () => {
+    it('finds FRAME blocks via findBlocksByType', () => {
+      engine.setBlock(5, 5, 5, BlockType.FRAME);
+
+      const frames = engine.findBlocksByType(BlockType.FRAME, 10);
+      expect(frames).toContainEqual({ x: 5, y: 5, z: 5 });
+    });
+
+    it('does not find non-FRAME blocks', () => {
+      engine.setBlock(5, 5, 5, BlockType.PANEL);
+      engine.setBlock(6, 6, 6, BlockType.SHELL);
+      engine.setBlock(7, 7, 7, BlockType.BLUEPRINT_FRAME);
+
+      const frames = engine.findBlocksByType(BlockType.FRAME, 10);
+      expect(frames.length).toBe(0);
+    });
+
+    it('removes a FRAME from the index when it is upgraded to PANEL', () => {
+      engine.setBlock(5, 5, 5, BlockType.FRAME);
+      expect(engine.findBlocksByType(BlockType.FRAME, 10)).toContainEqual({ x: 5, y: 5, z: 5 });
+
+      engine.setBlock(5, 5, 5, BlockType.PANEL);
+      expect(engine.findBlocksByType(BlockType.FRAME, 10).find((f) => f.x === 5 && f.y === 5 && f.z === 5)).toBeUndefined();
+    });
+
+    it('removes a FRAME from the index when it is removed', () => {
+      engine.setBlock(5, 5, 5, BlockType.FRAME);
+      engine.setBlock(5, 5, 5, BlockType.AIR);
+
+      expect(engine.findBlocksByType(BlockType.FRAME, 10).length).toBe(0);
+    });
+  });
+
+  // ── Buildable Panels index (PANEL → SHELL) ──────────────────────────────
+
+  describe('buildablePanels index', () => {
+    it('finds PANEL blocks via findBlocksByType', () => {
+      engine.setBlock(5, 5, 5, BlockType.PANEL);
+
+      const panels = engine.findBlocksByType(BlockType.PANEL, 10);
+      expect(panels).toContainEqual({ x: 5, y: 5, z: 5 });
+    });
+
+    it('does not find non-PANEL blocks', () => {
+      engine.setBlock(5, 5, 5, BlockType.SHELL);
+      engine.setBlock(6, 6, 6, BlockType.FRAME);
+
+      const panels = engine.findBlocksByType(BlockType.PANEL, 10);
+      expect(panels.length).toBe(0);
+    });
+
+    it('removes a PANEL from the index when it is upgraded to SHELL', () => {
+      engine.setBlock(5, 5, 5, BlockType.PANEL);
+      expect(engine.findBlocksByType(BlockType.PANEL, 10)).toContainEqual({ x: 5, y: 5, z: 5 });
+
+      engine.setBlock(5, 5, 5, BlockType.SHELL);
+      expect(engine.findBlocksByType(BlockType.PANEL, 10).find((p) => p.x === 5 && p.y === 5 && p.z === 5)).toBeUndefined();
+    });
+
+    it('removes a PANEL from the index when it is removed', () => {
+      engine.setBlock(5, 5, 5, BlockType.PANEL);
+      engine.setBlock(5, 5, 5, BlockType.AIR);
+
+      expect(engine.findBlocksByType(BlockType.PANEL, 10).length).toBe(0);
+    });
+  });
+
+  // ── World Reset ─────────────────────────────────────────────────────────
+
+  describe('world reset', () => {
+    it('clears all indexes after resetWorld', () => {
+      engine.setBlock(5, 5, 5, BlockType.ASTEROID_SURFACE);
+      engine.setBlock(10, 10, 10, BlockType.FRAME);
+      engine.setBlock(15, 15, 15, BlockType.PANEL);
+
+      expect(engine.findMiningTargets(10).length).toBeGreaterThan(0);
+      expect(engine.findBlocksByType(BlockType.FRAME, 10).length).toBeGreaterThan(0);
+      expect(engine.findBlocksByType(BlockType.PANEL, 10).length).toBeGreaterThan(0);
+
+      const blueprints = new BlueprintManager();
+      engine.resetWorld(blueprints);
+
+      expect(engine.findMiningTargets(10).length).toBe(0);
+      expect(engine.findBlocksByType(BlockType.FRAME, 10).length).toBe(0);
+      expect(engine.findBlocksByType(BlockType.PANEL, 10).length).toBe(0);
+    });
+
+    it('indexes stay consistent after generating a new asteroid post-reset', () => {
+      const blueprints = new BlueprintManager();
+      engine.resetWorld(blueprints);
+
+      engine.setBlock(5, 5, 5, BlockType.ASTEROID_SURFACE);
+
+      expect(engine.findMiningTargets(10)).toContainEqual({ x: 5, y: 5, z: 5 });
+    });
+  });
+
+  // ── Complex sequences ───────────────────────────────────────────────────
+
+  describe('complex sequences', () => {
+    it('handles a full lifecycle: mine → build frame → upgrade panel → upgrade shell', () => {
+      // 1. Place an asteroid block
+      engine.setBlock(5, 5, 5, BlockType.ASTEROID_SURFACE);
+      expect(engine.findMiningTargets(10)).toContainEqual({ x: 5, y: 5, z: 5 });
+
+      // 2. Mine it (set to AIR)
+      engine.setBlock(5, 5, 5, BlockType.AIR);
+      expect(engine.findMiningTargets(10).find((t) => t.x === 5 && t.y === 5 && t.z === 5)).toBeUndefined();
+
+      // 3. Build a frame in its place
+      engine.setBlock(5, 5, 5, BlockType.FRAME);
+      expect(engine.findBlocksByType(BlockType.FRAME, 10)).toContainEqual({ x: 5, y: 5, z: 5 });
+
+      // 4. Upgrade frame to panel
+      engine.setBlock(5, 5, 5, BlockType.PANEL);
+      expect(engine.findBlocksByType(BlockType.FRAME, 10).length).toBe(0);
+      expect(engine.findBlocksByType(BlockType.PANEL, 10)).toContainEqual({ x: 5, y: 5, z: 5 });
+
+      // 5. Upgrade panel to shell
+      engine.setBlock(5, 5, 5, BlockType.SHELL);
+      expect(engine.findBlocksByType(BlockType.PANEL, 10).length).toBe(0);
+    });
+
+    it('handles multiple scattered blocks correctly', () => {
+      const positions = [
+        { x: 1, y: 1, z: 1, type: BlockType.ASTEROID_SURFACE },
+        { x: 10, y: 20, z: 30, type: BlockType.ASTEROID_CORE },
+        { x: 100, y: 0, z: 50, type: BlockType.RARE_ORE },
+        { x: -5, y: -5, z: -5, type: BlockType.FRAME },
+        { x: 3, y: 3, z: 3, type: BlockType.PANEL },
+        { x: 7, y: 7, z: 7, type: BlockType.ASTEROID_SURFACE },
+      ] as const;
+
+      for (const p of positions) {
+        engine.setBlock(p.x, p.y, p.z, p.type);
+      }
+
+      const mines = engine.findMiningTargets(100);
+      const frames = engine.findBlocksByType(BlockType.FRAME, 100);
+      const panels = engine.findBlocksByType(BlockType.PANEL, 100);
+
+      // The three mine-type blocks should be in mining targets (exposed to AIR)
+      expect(mines).toContainEqual({ x: 1, y: 1, z: 1 });
+      expect(mines).toContainEqual({ x: 10, y: 20, z: 30 });
+      expect(mines).toContainEqual({ x: 100, y: 0, z: 50 });
+      expect(mines).toContainEqual({ x: 7, y: 7, z: 7 });
+
+      // The FRAME block should be in buildable frames
+      expect(frames).toContainEqual({ x: -5, y: -5, z: -5 });
+
+      // The PANEL block should be in buildable panels
+      expect(panels).toContainEqual({ x: 3, y: 3, z: 3 });
+
+      // SHELL and ASTEROID blocks should NOT appear as frames or panels
+      expect(frames.length).toBe(1);
+      expect(panels.length).toBe(1);
+    });
+
+    it('preserves index consistency after asteroid generation', () => {
+      engine.generateAsteroid(2, 0, 2, 5);
+
+      const targets = engine.findMiningTargets(100);
+      expect(targets.length).toBeGreaterThan(0);
+
+      // All targets should be valid mine type blocks
+      for (const target of targets) {
+        const block = engine.getBlock(target.x, target.y, target.z);
+        expect([BlockType.ASTEROID_SURFACE, BlockType.ASTEROID_CORE, BlockType.RARE_ORE]).toContain(
+          block,
+        );
+      }
+    });
+  });
+});

--- a/tests/services/bvx-engine-indexes.spec.ts
+++ b/tests/services/bvx-engine-indexes.spec.ts
@@ -192,6 +192,19 @@ describe('BvxEngine spatial indexes (issue #66)', () => {
 
       expect(engine.findBlocksByType(BlockType.PANEL, 10).length).toBe(0);
     });
+
+    it('respects the limit when finding PANEL blocks', () => {
+      // Place 5 PANEL blocks
+      engine.setBlock(0, 0, 0, BlockType.PANEL);
+      engine.setBlock(1, 0, 0, BlockType.PANEL);
+      engine.setBlock(2, 0, 0, BlockType.PANEL);
+      engine.setBlock(3, 0, 0, BlockType.PANEL);
+      engine.setBlock(4, 0, 0, BlockType.PANEL);
+
+      expect(engine.findBlocksByType(BlockType.PANEL, 3).length).toBe(3);
+      expect(engine.findBlocksByType(BlockType.PANEL, 10).length).toBe(5);
+      expect(engine.findBlocksByType(BlockType.PANEL, 0).length).toBe(0);
+    });
   });
 
   // ── World Reset ─────────────────────────────────────────────────────────

--- a/tests/services/voxel/voxel-query.spec.ts
+++ b/tests/services/voxel/voxel-query.spec.ts
@@ -2,43 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { VoxelQuery } from '../../../src/services/voxel/VoxelQuery';
 import { BlockType } from '../../../src/types';
 import { IVoxelSource } from '../../../src/services/voxel/types';
-import * as THREE from 'three';
-import type { Entity } from '../../../src/ecs/world';
 
 describe('VoxelQuery', () => {
-  // Mock world with a single block at 5,5,5
-  const mockVoxelSource: IVoxelSource = {
-    getBlock: (x: number, y: number, z: number) => {
-      if (x === 5 && y === 5 && z === 5) return BlockType.ASTEROID_SURFACE;
-      if (x === 10 && y === 10 && z === 10) return BlockType.FRAME;
-      return BlockType.AIR;
-    },
-  };
-
-  it('findBlueprints finds framework blocks', () => {
-    const chunkEntities: Entity[] = [
-      { chunkPosition: { x: 0, y: 0, z: 0 }, position: new THREE.Vector3(0, 0, 0) },
-      { chunkPosition: { x: 1, y: 1, z: 1 }, position: new THREE.Vector3(16, 16, 16) },
-    ];
-
-    const blueprints = VoxelQuery.findBlocksByType(chunkEntities, mockVoxelSource, BlockType.FRAME);
-
-    expect(blueprints).toContainEqual({ x: 10, y: 10, z: 10 });
-  });
-
-  it('findMiningTargets finds exposed asteroids', () => {
-    const chunkEntities: Entity[] = [
-      { chunkPosition: { x: 0, y: 0, z: 0 }, position: new THREE.Vector3(0, 0, 0) },
-    ];
-
-    const targets = VoxelQuery.findMiningTargets(chunkEntities, mockVoxelSource);
-    // 5,5,5 is ASTEROID_SURFACE.
-    // It has neighbors which are AIR (default mock).
-    // So it is exposed.
-
-    expect(targets).toContainEqual({ x: 5, y: 5, z: 5 });
-  });
-
   describe('isChunkCompletedDyson', () => {
     it('returns false for an empty (all-AIR) chunk', () => {
       const emptySource: IVoxelSource = { getBlock: () => BlockType.AIR };


### PR DESCRIPTION
## Summary

Closes #66

Replaces the brute-force `O(chunks × 16³)` scans in `VoxelQuery.findMiningTargets` and `VoxelQuery.findBlocksByType` with incremental spatial index sets maintained by `BvxEngine.setBlock`.

## Changes

### `src/services/BvxEngine.ts`
- Added three `Set<string>` fields: `exposedMines`, `buildableFrames`, `buildablePanels`
- Added helper methods for incremental index maintenance:
  - `isMineType()` — checks if a block type is minable
  - `isExposed()` — checks if a block has an AIR/FRAME neighbor
  - `evaluateBlockForMining()` — updates `exposedMines` for a single position
  - `evaluateBlockForBuilding()` — updates `buildableFrames`/`buildablePanels`
  - `updateSpatialIndexes()` — re-evaluates the changed position + 6 neighbors
- `setBlock()` now calls `updateSpatialIndexes()` after each block change
- `findMiningTargets()` and `findBlocksByType()` query the sets directly (`O(candidates)`)
- `resetWorld()` clears all indexes

### `src/services/voxel/VoxelQuery.ts`
- Removed `findBlocksByType` and `findMiningTargets` (including the `Math.random() < 0.05` debug log)
- Kept `isChunkCompletedDyson` (per-chunk query, not a world scan)

### Tests
- `tests/services/bvx-engine-indexes.spec.ts` — 22 new tests covering:
  - Each mine type (surface, core, rare ore) appearing in `exposedMines`
  - Non-exposed buried blocks excluded
  - Non-mine types excluded
  - Block removal updating indexes
  - Neighbor changes updating exposure
  - FRAME → PANEL → SHELL lifecycle
  - World reset
  - Complex multi-block sequences
  - Post-reset consistency
  - Asteroid generation integration

## Verification

- ✅ `pnpm test` — 195 tests pass (33 files)
- ✅ `pnpm lint` — no errors
- ✅ `pnpm typecheck` — no errors  
- ✅ `pnpm build` — builds successfully